### PR TITLE
Redirect auth if provider available

### DIFF
--- a/app/controllers/spree/user_sessions_controller_decorator.rb
+++ b/app/controllers/spree/user_sessions_controller_decorator.rb
@@ -1,0 +1,18 @@
+Spree::UserSessionsController.class_eval do
+  before_action :redirect_to_wonderful_union,
+    only: :new,
+    if: :wonderful_union_available?
+
+  protected
+
+  def redirect_to_wonderful_union
+    redirect_to(
+      spree.spree_user_omniauth_authorize_url(provider: "wonderful_union")
+    )
+  end
+
+  def wonderful_union_available?
+    Spree::AuthenticationMethod.available_for(@spree_user).
+      where(active: true, provider: "wonderful_union").any?
+  end
+end

--- a/spec/features/spree/sign_in_spec.rb
+++ b/spec/features/spree/sign_in_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature 'signing in using Omniauth', :js do
     scenario 'going to sign in' do
       visit spree.root_path
       click_link 'Login'
-      find('a#wonderful-union').trigger('click')
+
       expect(page).to have_text 'You are now signed in with your Wonderful Union account.'
     end
   end


### PR DESCRIPTION
When the "Login" button is clicked and an oauth provider is avilable, log in to Spree using the WU provider instead of logging in through Spree.

If no provider is available, the regular Spree login form is shown without any notifications. If one or more providers is available, it attempts to use the first one available.