### PR TITLE
Fix issues with running tests locally

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,10 @@ rescue LoadError
   exit
 end
 
+Rails.application.configure do
+  config.assets.precompile += %w(logo/spree_50.png favicon.ico)
+end
+
 require 'rspec/rails'
 require 'ffaker'
 


### PR DESCRIPTION
Because spree_social is an engine, before you run tests, you need to run
`rake test_app`. This will generate a dummy Rails app located in
`spec/dummy` that is used to initialize the engine. The problem is, this
app doesn't seem to be complete: when running the feature tests, I was
getting errors indicating that `logo/spree_50.png` and `favicon.ico`
were outside of the bundle and needed to be included. I'm not sure if
this is fixed in later versions of Spree, but to ensure this doesn't
happen again, I've modified spec_helper.rb to add them to
`Rails.application.configuration.assets.precompile`.