### PR TITLE
Extract configuration options to Configuration

### DIFF
--- a/lib/spree_social.rb
+++ b/lib/spree_social.rb
@@ -1,9 +1,11 @@
 require 'spree_core'
 require 'spree_auth_devise'
 require 'omniauth-wonderful-union'
+require 'coffee_script'
+
+require 'spree_social/configuration'
 require 'spree_social/engine'
 require 'spree_social/version'
-require 'coffee_script'
 
 module SpreeSocial
   OAUTH_PROVIDERS = [
@@ -11,19 +13,15 @@ module SpreeSocial
   ]
 
   def self.configure(&block)
-    yield self
+    yield configuration
   end
 
-  def self.authorization_proc=(auth_proc)
-    @authorization_proc = auth_proc
+  def self.configuration
+    @_configuration ||= Configuration.new
   end
 
   def self.authorization
-    if @authorization_proc
-      @authorization_proc.call
-    else
-      Spree::AuthenticationMethod.find_by!(environment: ::Rails.env)
-    end
+    configuration.find_authentication_method.call
   end
 
   # Setup all OAuth providers
@@ -42,7 +40,6 @@ module SpreeSocial
   end
 
   def self.setup_key_for(provider, key, secret)
-
     Devise.setup do |config|
       config.omniauth provider, key, secret, options
     end

--- a/lib/spree_social/configuration.rb
+++ b/lib/spree_social/configuration.rb
@@ -1,0 +1,11 @@
+module SpreeSocial
+  class Configuration
+    attr_accessor :find_authentication_method
+
+    def initialize
+      @find_authentication_method = lambda do
+        Spree::AuthenticationMethod.find_by!(environment: ::Rails.env)
+      end
+    end
+  end
+end

--- a/spec/lib/spree_social/configuration_spec.rb
+++ b/spec/lib/spree_social/configuration_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe SpreeSocial::Configuration do
+  subject(:configuration) { described_class.new }
+
+  describe '#find_authentication_method' do
+    it 'finds the first AuthenticationMethod belonging to the current Rails ' \
+    'environment by default' do
+      authentication_method = double(:authentication_method)
+      rails_environment = 'some-environment'
+      allow(Rails).to receive(:env).and_return(rails_environment)
+      allow(Spree::AuthenticationMethod).
+        to receive(:find_by!).
+        with(environment: rails_environment).
+        and_return(authentication_method)
+
+      expect(configuration.find_authentication_method.call).
+        to eq authentication_method
+    end
+
+    it 'is overridable' do
+      authentication_method = double(:authentication_method)
+      configuration.find_authentication_method = -> { authentication_method }
+
+      expect(configuration.find_authentication_method.call).
+        to eq authentication_method
+    end
+  end
+end

--- a/spec/lib/spree_social_spec.rb
+++ b/spec/lib/spree_social_spec.rb
@@ -9,36 +9,21 @@ RSpec.describe SpreeSocial do
   end
 
   describe ".configure" do
-    it "yields itself" do
+    it "yields an instance of Spree::Configuration" do
       expect { |block| SpreeSocial.configure(&block) }.
-        to yield_with_args(SpreeSocial)
+        to yield_with_args(instance_of(SpreeSocial::Configuration))
     end
   end
 
   describe ".authorization" do
-    context "with authorization_proc" do
-      it "returns the response of #call" do
-        response = double
-        SpreeSocial.authorization_proc = -> { response }
+    it "returns the result of calling the find_authentication_method configuration setting" do
+      fake_authentication_method = double(:authentication_method)
+      find_authentication_method = -> { fake_authentication_method }
+      allow(SpreeSocial.configuration).
+        to receive(:find_authentication_method).
+        and_return(find_authentication_method)
 
-        expect(SpreeSocial.authorization).to eq response
-      end
-
-      after do
-        SpreeSocial.authorization_proc = nil
-      end
-    end
-
-    context "without authorization_proc" do
-      it "calls Spree::AuthenticationMethod.find_by!" do
-        response = double
-        allow(Spree::AuthenticationMethod).to receive(:find_by!) { response }
-
-        expect(SpreeSocial.authorization).to eq response
-        expect(Spree::AuthenticationMethod).to have_received(:find_by!).with(
-          environment: ::Rails.env
-        )
-      end
+      expect(SpreeSocial.authorization).to eq fake_authentication_method
     end
   end
 


### PR DESCRIPTION
Right now, configuration options are class methods on SpreeSocial. These
options are hard to test because if you want to set an option in a test,
then it changes global state and you have to make sure to roll it back
so that it doesn't affect future tests. Instead of doing that, extract
these options to a class, so that when setting an option you will do so
on a Configuration instance.