### PR TITLE
Fix OmniAuth auth failure proc

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -6,8 +6,13 @@ OmniAuth.config.logger = Logger.new(STDOUT)
 OmniAuth.logger.progname = 'omniauth'
 
 OmniAuth.config.on_failure = proc do |env|
-  env['devise.mapping'] = Devise.mappings[Spree.user_class.table_name.singularize.to_sym]
-  controller_name  = ActiveSupport::Inflector.camelize(env['devise.mapping'].controllers[:omniauth_callbacks])
-  controller_klass = ActiveSupport::Inflector.constantize("#{controller_name}Controller")
-  controller_klass.action(:failure).call(env)
+  devise_scope = Spree.user_class.table_name.split('.').last.singularize.to_sym
+  env['devise.mapping'] = Devise.mappings.fetch(devise_scope)
+  controller_name = ActiveSupport::Inflector.camelize(
+    env['devise.mapping'].controllers[:omniauth_callbacks]
+  )
+  controller_class = ActiveSupport::Inflector.constantize(
+    "#{controller_name}Controller"
+  )
+  controller_class.action(:failure).call(env)
 end


### PR DESCRIPTION
Currently we configure OmniAuth so that if the authorization step fails,
the `failure` action in Spree::OmniauthCallbacksController is called.
This controller is obtained by taking the configured Spree user class
(Spree::User), asking for its table name (`spree_users`), then looking
up the singular version of that table name (`:spree_user`) in the
`Devise.mappings` hash.

The problem is, since we've reconfigured Postgres to use multiple
tenants, the result of asking for the table name of any model is going
to start with `public.` (or whatever the tenant is, plus `.`).
So the key we look up might be `:'public.spree_user'`, not
`:spree_user`.

Fix this by essentially taking away the tenant name before looking it up
in `Devise.mappings`. Also, use `fetch` to look up the key, so if it
doesn't exist, we get a more informative error immediately.